### PR TITLE
Post relative

### DIFF
--- a/src/check_archives.ts
+++ b/src/check_archives.ts
@@ -6,7 +6,7 @@ export async function checkArchives(groups: LURLGroup[]) {
   errorGroups = errorGroups.slice(0, 50);
   if (!errorGroups.length) return;
 
-  const archiveStatus = await queryIA(errorGroups.map((group) => group.url));
+  const archiveStatus = await queryIA(errorGroups);
 
   for (let result of archiveStatus.results) {
     if (result.archived_snapshots?.closest?.available) {

--- a/src/ia_client.ts
+++ b/src/ia_client.ts
@@ -1,3 +1,4 @@
+import Https from "https";
 import Http from "http";
 import Path from "path";
 import Querystring from "querystring";
@@ -5,7 +6,7 @@ import { IAResults, LURLGroup } from "../types";
 
 // https://github.com/internetarchive/internetarchivebot/blob/master/app/src/Core/APII.php#L2429
 
-const ENDPOINT = `http://archive.org/wayback/available`;
+const ENDPOINT = `https://archive.org/wayback/available`;
 const HEADERS = {
   "Wayback-Api-Version": 2,
 };
@@ -67,7 +68,7 @@ export function queryIA(groups: LURLGroup[]): Promise<IAResults> {
       });
     }
 
-    const req = Http.request(
+    const req = Https.request(
       ENDPOINT,
       {
         method: "POST",

--- a/src/ia_client.ts
+++ b/src/ia_client.ts
@@ -1,5 +1,7 @@
 import Http from "http";
-import { IAResults } from "../types";
+import Path from "path";
+import Querystring from "querystring";
+import { IAResults, LURLGroup } from "../types";
 
 // https://github.com/internetarchive/internetarchivebot/blob/master/app/src/Core/APII.php#L2429
 
@@ -8,16 +10,47 @@ const HEADERS = {
   "Wayback-Api-Version": 2,
 };
 
-function encodeURLs(urls: string[]) {
-  return urls
-    .map(
-      (url, i) =>
-        `url=${url}&closest=before&statuscodes=200&statuscodes=203&statuscodes=206&tag=${i}`
-    )
+export function dateFromFilename(filename: string) {
+  const match = filename.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (match) {
+    // Month here is 'monthIndex', a weird API, zero-indexed. Be careful.
+    return new Date(+match[1], parseInt(match[2], 10) - 1, +match[3]);
+  }
+}
+
+function dateForGroup(group: LURLGroup) {
+  const dates = group.files
+    .map((file) => dateFromFilename(Path.basename(file.filename)))
+    .filter(Boolean) as Date[];
+  dates.sort((a, b) => +b - +a);
+  if (dates.length) return dates[0];
+}
+
+export function formatDate(date: Date | undefined) {
+  if (!date) return;
+  // date( 'YmdHis', $time )
+  const y = date.getFullYear();
+  const m = (date.getMonth() + 1).toString().padStart(2, "0");
+  const d = date.getDate().toString().padStart(2, "0");
+  return `${y}${m}${d}000000`;
+}
+
+function encodeURLs(groups: LURLGroup[]) {
+  return groups
+    .map((group, i) => {
+      const firstDate = dateForGroup(group);
+      return Querystring.stringify({
+        url: group.url,
+        timestamp: formatDate(firstDate),
+        closest: "before",
+        statuscodes: [200, 203, 206],
+        tag: i,
+      });
+    })
     .join("\n");
 }
 
-export function queryIA(urls: string[]): Promise<IAResults> {
+export function queryIA(groups: LURLGroup[]): Promise<IAResults> {
   return new Promise((resolve, reject) => {
     function handleResponse(res: Http.IncomingMessage) {
       let body = "";
@@ -45,7 +78,7 @@ export function queryIA(urls: string[]): Promise<IAResults> {
     req.on("error", (e) => {
       reject(e);
     });
-    req.write(encodeURLs(urls));
+    req.write(encodeURLs(groups));
     req.end();
   });
 }

--- a/test/check_archives.ts
+++ b/test/check_archives.ts
@@ -1,0 +1,84 @@
+import { test } from "tap";
+import { checkArchives } from "../src/check_archives";
+import { toLFile, groupFiles } from "../src/util";
+import { testContext } from "./helpers";
+import type { IAResults } from "../types";
+import Path from "path";
+import Nock from "nock";
+
+test("checkArchives - found", async (t) => {
+  const ctx = testContext();
+
+  const lFile = toLFile(
+    Path.join(__dirname, "./fixtures/example.md"),
+    "fixtures/example.md"
+  );
+
+  const groups = groupFiles(ctx, [lFile]);
+
+  groups[0].status = {
+    status: "error",
+  };
+
+  const fakeResult: IAResults = {
+    results: [
+      {
+        url: "http://google.com/",
+        tag: "0",
+        archived_snapshots: {
+          closest: {
+            url: "https://archived.com/google",
+            status: "ok",
+            timestamp: "1",
+            available: true,
+          },
+        },
+      },
+    ],
+  };
+
+  Nock("https://archive.org").post("/wayback/available").reply(200, fakeResult);
+  await checkArchives(groups);
+  t.same(groups[0].status, {
+    status: "archive",
+    to: "https://archived.com/google",
+  });
+});
+
+test("checkArchives - not found", async (t) => {
+  const ctx = testContext();
+
+  const lFile = toLFile(
+    Path.join(__dirname, "./fixtures/example.md"),
+    "fixtures/example.md"
+  );
+
+  const groups = groupFiles(ctx, [lFile]);
+
+  groups[0].status = {
+    status: "error",
+  };
+
+  const fakeResult: IAResults = {
+    results: [
+      {
+        url: "http://google.com/",
+        tag: "0",
+        archived_snapshots: {
+          closest: {
+            url: "https://archived.com/google",
+            status: "ok",
+            timestamp: "1",
+            available: false,
+          },
+        },
+      },
+    ],
+  };
+
+  Nock("https://archive.org").post("/wayback/available").reply(200, fakeResult);
+  await checkArchives(groups);
+  t.same(groups[0].status, {
+    status: "error",
+  });
+});

--- a/test/ia_client.ts
+++ b/test/ia_client.ts
@@ -1,15 +1,25 @@
 import { test } from "tap";
-import { queryIA } from "../src/ia_client";
+import { queryIA, dateFromFilename, formatDate } from "../src/ia_client";
+import { toLFile, groupFiles } from "../src/util";
+import { testContext } from "./helpers";
+import Path from "path";
 
-test("queryIA", async (t) => {
-  const url = "http://thiswebsiteneverexisted.com";
-  t.same(await queryIA([url]), {
-    results: [
-      {
-        archived_snapshots: {},
-        tag: "0",
-        url,
-      },
-    ],
-  });
+test("dateFromFilename", async (t) => {
+  t.same(formatDate(dateFromFilename("2000-01-01-foo")), "20000101000000");
+});
+
+test("formatDate", async (t) => {
+  t.same(formatDate(new Date(2000, 0, 2)), "20000102000000");
+});
+
+test("queryIA with no groups", async (t) => {
+  const ctx = testContext();
+
+  const lFile = toLFile(
+    Path.join(__dirname, "./fixtures/example.md"),
+    "fixtures/example.md"
+  );
+
+  const groups = groupFiles(ctx, [lFile]);
+  t.same((await queryIA(groups)).results.length, 3);
 });


### PR DESCRIPTION
First trial run uncovered some issues - URLs that were linked to long ago have gone missing, but the most recent Internet Archive run on them turned up a 301 or something else.

This borrows another technique from the Wikipedia bot - it tries to determine the post's date, and searches for an archived version around that time.

Also introduces tests for the archive process, using Nock again to avoid actual traffic.